### PR TITLE
feat(user-settings): implement get user settings functionality

### DIFF
--- a/apps/api-gateway/src/consumers/user-settings.consumer.ts
+++ b/apps/api-gateway/src/consumers/user-settings.consumer.ts
@@ -26,6 +26,11 @@ export class UserSettingsConsumer implements OnModuleInit {
       fromBeginning: false,
     });
 
+    await this.consumer.subscribe({
+      topic: 'get-user-settings-response',
+      fromBeginning: false,
+    });
+
     await this.consumer.run({
       autoCommit: false,
       eachMessage: async (message: EachMessagePayload) => {
@@ -42,6 +47,19 @@ export class UserSettingsConsumer implements OnModuleInit {
               `Received response for request ${event.requestId}:`,
               event,
             );
+            this.userSettingsService.saveResponse(event.requestId, event);
+            break;
+          }
+
+          case 'get-user-settings-response': {
+            const event = JSON.parse(
+              message.message.value.toString(),
+            ) as UserSettingsResponse;
+            this.logger.log(
+              `Received response for request ${event.requestId}:`,
+              event,
+            );
+
             this.userSettingsService.saveResponse(event.requestId, event);
             break;
           }

--- a/apps/api-gateway/src/controllers/user-settings/dtos/update-user-avatar.dto.ts
+++ b/apps/api-gateway/src/controllers/user-settings/dtos/update-user-avatar.dto.ts
@@ -21,3 +21,10 @@ export class UpdateUserAvatarRequestDto {
   })
   avatarUrl: string;
 }
+
+export class GetUserSettingsRequestDto {
+  @ApiProperty({
+    example: '1234-1234-1234-1234',
+  })
+  userId: string;
+}

--- a/apps/api-gateway/src/controllers/user-settings/user-settings.controller.ts
+++ b/apps/api-gateway/src/controllers/user-settings/user-settings.controller.ts
@@ -5,13 +5,15 @@ import {
   BadRequestException,
   HttpStatus,
   UnauthorizedException,
+  Get,
+  Query,
 } from '@nestjs/common';
 import { Post, Inject } from '@nestjs/common';
 import { ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ClientKafka } from '@nestjs/microservices';
 import { Logger } from 'libs/logger';
 import { UserSettingsService } from '../../services';
-import { UpdateUserAvatarRequestDto } from './dtos';
+import { GetUserSettingsRequestDto, UpdateUserAvatarRequestDto } from './dtos';
 import { AuthHelper } from 'apps/auth/src/helpers';
 import { SessionToken } from 'libs/session-token-decorator';
 
@@ -25,6 +27,55 @@ export class UserSettingsController {
     @Inject('KAFKA_SERVICE') private readonly kafkaClient: ClientKafka,
   ) {
     logger.setContext(UserSettingsController.name);
+  }
+
+  @Get('get-user-settings')
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'USER_SETTINGS_FETCHED_SUCCESSFULLY',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'UNKNOWN_ERROR',
+  })
+  public async getUserSettings(
+    @Query() query: GetUserSettingsRequestDto,
+    @SessionToken() sessionToken: string,
+  ) {
+    const userId = await this.authHelper.getUserIdBySessionToken(sessionToken);
+    if (!userId) throw new UnauthorizedException('UNAUTHORIZED');
+
+    const requestId = crypto.randomUUID();
+    this.kafkaClient.emit('get-user-settings', {
+      ...query,
+      userId: userId.value,
+      requestId,
+    });
+
+    try {
+      const response = await this.userSettingsService.waitForResponse(
+        requestId,
+        30000,
+      );
+      return response;
+    } catch (error) {
+      this.logger.error(
+        { message: 'Error waiting for response', error: String(error) },
+        'UserSettingsController',
+      );
+      if (error instanceof ConflictException) {
+        throw new ConflictException(error.message);
+      }
+      if (error instanceof BadRequestException) {
+        throw new BadRequestException({
+          message: error.message,
+          status: 'BAD_REQUEST',
+        });
+      }
+      if (error instanceof Error) {
+        throw new Error(error.message);
+      }
+    }
   }
 
   @Post('update-user-avatar')

--- a/apps/user/src/core/application/index.ts
+++ b/apps/user/src/core/application/index.ts
@@ -1,2 +1,5 @@
 export * from './commands';
 export * from './commands-handlers';
+export * from './queries';
+export * from './queries-handlers';
+export * from './query-repositories';

--- a/apps/user/src/core/application/queries-handlers/get-user-settings.query-handler.ts
+++ b/apps/user/src/core/application/queries-handlers/get-user-settings.query-handler.ts
@@ -1,0 +1,38 @@
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { GetUserSettingsQuery, GetUserSettingsQueryResponse } from '../queries';
+import { UserNotFoundDomainError } from '../../domain';
+import { UserSettingsQueryRepository } from '../query-repositories';
+
+@QueryHandler(GetUserSettingsQuery)
+export class GetUserSettingsQueryHandler
+  implements IQueryHandler<GetUserSettingsQuery>
+{
+  constructor(
+    public readonly userSettingsQueryRepository: UserSettingsQueryRepository,
+  ) {}
+
+  async execute(
+    query: GetUserSettingsQuery,
+  ): Promise<GetUserSettingsQueryResponse | UserNotFoundDomainError> {
+    const result = await this.userSettingsQueryRepository.findById(
+      query.userId,
+    );
+
+    if (result.isErr()) {
+      return result.error;
+    }
+
+    const userSettings = result.value;
+
+    const response: GetUserSettingsQueryResponse = {
+      id: userSettings.id.value,
+      userId: userSettings.userId.value,
+      avatarUrl: userSettings.avatarUrl.value || '',
+      settings: userSettings.settings,
+      createdAt: userSettings.createdAt,
+      updatedAt: userSettings.updatedAt,
+    };
+
+    return response;
+  }
+}

--- a/apps/user/src/core/application/queries-handlers/index.ts
+++ b/apps/user/src/core/application/queries-handlers/index.ts
@@ -1,0 +1,1 @@
+export * from './get-user-settings.query-handler';

--- a/apps/user/src/core/application/queries/get-user-settings.query.ts
+++ b/apps/user/src/core/application/queries/get-user-settings.query.ts
@@ -1,0 +1,19 @@
+import { Query } from '@nestjs/cqrs';
+import { UserIdVO, UserNotFoundDomainError } from '../../domain';
+
+export interface GetUserSettingsQueryResponse {
+  avatarUrl: string;
+  settings: Record<string, any>;
+  createdAt: Date;
+  updatedAt: Date;
+  id: string;
+  userId: string;
+}
+
+export class GetUserSettingsQuery extends Query<
+  GetUserSettingsQueryResponse | UserNotFoundDomainError
+> {
+  constructor(public readonly userId: UserIdVO) {
+    super();
+  }
+}

--- a/apps/user/src/core/application/queries/index.ts
+++ b/apps/user/src/core/application/queries/index.ts
@@ -1,0 +1,1 @@
+export * from './get-user-settings.query';

--- a/apps/user/src/core/application/query-repositories/index.ts
+++ b/apps/user/src/core/application/query-repositories/index.ts
@@ -1,0 +1,1 @@
+export * from './user-settings.query-repository';

--- a/apps/user/src/core/application/query-repositories/user-settings.query-repository.ts
+++ b/apps/user/src/core/application/query-repositories/user-settings.query-repository.ts
@@ -1,0 +1,9 @@
+import { Result } from 'neverthrow';
+import { UserNotFoundDomainError, UserSettings } from '../../domain';
+import { UserIdVO } from '../../domain';
+
+export abstract class UserSettingsQueryRepository {
+  public abstract findById(
+    id: UserIdVO,
+  ): Promise<Result<UserSettings, UserNotFoundDomainError>>;
+}

--- a/apps/user/src/core/infrastructure/query-repositories/index.ts
+++ b/apps/user/src/core/infrastructure/query-repositories/index.ts
@@ -1,0 +1,1 @@
+export * from './user-settings.query-repository';

--- a/apps/user/src/core/infrastructure/query-repositories/user-settings.query-repository.ts
+++ b/apps/user/src/core/infrastructure/query-repositories/user-settings.query-repository.ts
@@ -1,0 +1,58 @@
+import { TransactionalAdapterPgPromise } from '@nestjs-cls/transactional-adapter-pg-promise';
+import { Injectable } from '@nestjs/common';
+import { UserSettingsQueryRepository } from '../../application';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { err, ok, Result } from 'neverthrow';
+import {
+  UserIdVO,
+  UserSettings,
+  UserNotFoundDomainError,
+  AvatarUrlVO,
+} from '../../domain';
+import { knex } from 'knex';
+import { UserSettingsSchema } from 'adapters/database-adapter';
+
+@Injectable()
+export class UserSettingsQueryRepositoryImpl
+  implements UserSettingsQueryRepository
+{
+  private readonly knex = knex({ client: 'pg' });
+
+  constructor(
+    private readonly txHost: TransactionHost<TransactionalAdapterPgPromise>,
+  ) {}
+
+  public async findById(
+    id: UserIdVO,
+  ): Promise<Result<UserSettings, UserNotFoundDomainError>> {
+    const SQL = this.knex<UserSettingsSchema>('users-settings')
+      .select('*')
+      .where('user_id', id.value)
+      .toSQL()
+      .toNative();
+
+    const dbUser = await this.txHost.tx.oneOrNone<UserSettingsSchema>(
+      SQL.sql,
+      SQL.bindings,
+    );
+
+    if (!dbUser) {
+      return err(new UserNotFoundDomainError(id.value));
+    }
+
+    try {
+      const userSettings = new UserSettings(
+        new UserIdVO(dbUser.id),
+        new UserIdVO(dbUser.user_id),
+        new AvatarUrlVO(dbUser.avatar_url),
+        dbUser.settings,
+        new Date(dbUser.created_at),
+        new Date(dbUser.updated_at),
+      );
+
+      return ok(userSettings);
+    } catch {
+      return err(new UserNotFoundDomainError(id.value));
+    }
+  }
+}

--- a/apps/user/src/core/presentation/dtos/update-user-avatar.dto.ts
+++ b/apps/user/src/core/presentation/dtos/update-user-avatar.dto.ts
@@ -3,3 +3,8 @@ export class UpdateUserAvatarDto {
   avatarUrl: string;
   requestId: string;
 }
+
+export class GetUserSettingsDto {
+  userId: string;
+  requestId: string;
+}

--- a/apps/user/src/core/presentation/user-settings.controller.ts
+++ b/apps/user/src/core/presentation/user-settings.controller.ts
@@ -2,8 +2,11 @@ import { Controller, Inject } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { Logger } from 'libs/logger';
 import { ClientKafka, MessagePattern, Payload } from '@nestjs/microservices';
-import { UpdateUserAvatarDto } from './dtos/update-user-avatar.dto';
-import { UpdateUserAvatarCommand } from '../application';
+import {
+  GetUserSettingsDto,
+  UpdateUserAvatarDto,
+} from './dtos/update-user-avatar.dto';
+import { GetUserSettingsQuery, UpdateUserAvatarCommand } from '../application';
 import { UserIdVO } from 'apps/auth/src';
 import { AvatarUrlVO, UserNotFoundDomainError } from '../domain';
 import { ValidationException } from 'libs/validation-exception';
@@ -69,6 +72,44 @@ export class UserSettingsController {
         'UserSettingsController',
       );
       this.kafkaClient.emit('update-user-avatar-response', {
+        userId: payload.userId,
+        status: 'BAD_REQUEST',
+        message: 'UNKNOWN_ERROR',
+        requestId: payload.requestId,
+      });
+    }
+  }
+
+  @MessagePattern('get-user-settings')
+  async getUserSettings(@Payload() payload: GetUserSettingsDto) {
+    try {
+      const result = await this.queryBus.execute(
+        new GetUserSettingsQuery(new UserIdVO(payload.userId)),
+      );
+
+      if (result instanceof UserNotFoundDomainError) {
+        this.kafkaClient.emit('get-user-settings-response', {
+          userId: payload.userId,
+          status: 'NOT_FOUND',
+          message: 'USER_NOT_FOUND',
+          requestId: payload.requestId,
+        });
+        return;
+      }
+
+      this.kafkaClient.emit('get-user-settings-response', {
+        status: 'SUCCESS',
+        message: 'USER_SETTINGS_FETCHED_SUCCESSFULLY',
+        result: result,
+        requestId: payload.requestId,
+      });
+      return;
+    } catch (error) {
+      this.logger.error(
+        { message: 'Error getting user settings', error: String(error) },
+        'UserSettingsController',
+      );
+      this.kafkaClient.emit('get-user-settings-response', {
         userId: payload.userId,
         status: 'BAD_REQUEST',
         message: 'UNKNOWN_ERROR',

--- a/apps/user/src/module/module.providers.ts
+++ b/apps/user/src/module/module.providers.ts
@@ -5,14 +5,23 @@ import {
   UpdateUserAvatarCommandHandler,
 } from '../core/application/commands-handlers';
 import { UserSettingsConsumer } from '../core/presentation/consumers/user-settings.consumer';
+import { GetUserSettingsQueryHandler } from '../core/application/queries-handlers/get-user-settings.query-handler';
+import { UserSettingsQueryRepository } from '../core/application/query-repositories';
+import { UserSettingsQueryRepositoryImpl } from '../core/infrastructure/query-repositories/user-settings.query-repository';
 
 export const commandHandlersProviders = [
   UpdateUserAvatarCommandHandler,
   CreateUserSettingsCommandHandler,
 ];
 
+export const queryHandlersProviders = [GetUserSettingsQueryHandler];
+
 export const repositoriesProviders = [
   { provide: UserSettingsRepository, useClass: UserSettingsRepostitoryImpl },
+  {
+    provide: UserSettingsQueryRepository,
+    useClass: UserSettingsQueryRepositoryImpl,
+  },
 ];
 
 export const consumersProviders = [UserSettingsConsumer];

--- a/apps/user/src/module/module.ts
+++ b/apps/user/src/module/module.ts
@@ -4,9 +4,13 @@ import { ClientsModule, Transport } from '@nestjs/microservices';
 import { KafkaConfig } from 'adapters/config-adapter';
 import { KafkaModule } from 'adapters/kafka-adapter';
 import { UserSettingsController } from '../core/presentation';
-import { commandHandlersProviders } from './module.providers';
+import {
+  commandHandlersProviders,
+  queryHandlersProviders,
+} from './module.providers';
 import { repositoriesProviders } from './module.providers';
 import { consumersProviders } from './module.providers';
+import { queryRepositoriesProviders } from 'apps/auth/src/module/module.providers';
 
 @Global()
 @Module({
@@ -35,6 +39,8 @@ import { consumersProviders } from './module.providers';
   controllers: [UserSettingsController],
   providers: [
     ...commandHandlersProviders,
+    ...queryHandlersProviders,
+    ...queryRepositoriesProviders,
     ...repositoriesProviders,
     ...consumersProviders,
   ],


### PR DESCRIPTION
- Added a new endpoint to fetch user settings via a GET request.
- Implemented a Kafka consumer to handle 'get-user-settings' messages and respond with user settings or an error.
- Created necessary DTOs for request and response handling.
- Introduced query and query handler for retrieving user settings from the database.
- Updated module providers to include new query handlers and repositories.